### PR TITLE
Add support for deletion of a certain property

### DIFF
--- a/presto-manager-agent/src/main/java/com/teradata/prestomanager/agent/ApiFileHandler.java
+++ b/presto-manager-agent/src/main/java/com/teradata/prestomanager/agent/ApiFileHandler.java
@@ -169,7 +169,7 @@ public class ApiFileHandler
         try {
             AgentFileUtils.removePropertyFromFile(Paths.get(baseDir.toString(), path), property);
             LOGGER.debug("Deleted property '%s' from file '%s'", property, path);
-            return Response.status(Status.ACCEPTED)
+            return Response.status(Status.OK)
                     .entity("Deleted property").build();
         }
         catch (NoSuchElementException | FileNotFoundException e) {

--- a/presto-manager-agent/src/main/java/com/teradata/prestomanager/agent/api/ConfigAPI.java
+++ b/presto-manager-agent/src/main/java/com/teradata/prestomanager/agent/api/ConfigAPI.java
@@ -128,4 +128,18 @@ public final class ConfigAPI
     {
         return apiFileHandler.deleteFile(file);
     }
+
+    @DELETE
+    @Path("/{file}/{property}")
+    @ApiOperation(value = "Delete a property from a configuration file")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Property deleted"),
+            @ApiResponse(code = 404, message = "Resource not found"),
+            @ApiResponse(code = 409, message = "Request conflicts with current state")})
+    public synchronized Response deletePropertyFromFile(
+            @PathParam("file") @ApiParam("The name of a file") String file,
+            @PathParam("property") @ApiParam("A specific property") String property)
+    {
+        return apiFileHandler.deletePropertyFromFile(file, property);
+    }
 }

--- a/presto-manager-agent/src/main/java/com/teradata/prestomanager/agent/api/ConnectorsAPI.java
+++ b/presto-manager-agent/src/main/java/com/teradata/prestomanager/agent/api/ConnectorsAPI.java
@@ -126,4 +126,18 @@ public final class ConnectorsAPI
     {
         return apiFileHandler.deleteFile(file);
     }
+
+    @DELETE
+    @Path("/{file}/{property}")
+    @ApiOperation(value = "Delete a property from a connector file")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Property deleted"),
+            @ApiResponse(code = 404, message = "Resource not found"),
+            @ApiResponse(code = 409, message = "Request conflicts with current state")})
+    public synchronized Response deletePropertyFromFile(
+            @PathParam("file") @ApiParam("The name of a file") String file,
+            @PathParam("property") @ApiParam("A specific property") String property)
+    {
+        return apiFileHandler.deletePropertyFromFile(file, property);
+    }
 }

--- a/presto-manager-controller/src/main/java/com/teradata/prestomanager/controller/api/ControllerConfigAPI.java
+++ b/presto-manager-controller/src/main/java/com/teradata/prestomanager/controller/api/ControllerConfigAPI.java
@@ -191,4 +191,27 @@ public class ControllerConfigAPI
 
         return forwardRequest(scope, apiRequester, nodeId);
     }
+
+    @DELETE
+    @Path("/{file}/{property}")
+    @ApiOperation(value = "Delete a certain property of configuration file")
+    @ApiResponses(value = {
+            @ApiResponse(code = 207, message = "Multiple responses available"),
+            @ApiResponse(code = 400, message = "Request contains invalid parameters")})
+    public Response deleteConfigProperty(
+            @PathParam("file") String file,
+            @PathParam("property") String property,
+            @QueryParam("scope") String scope,
+            @QueryParam("nodeId") List<UUID> nodeId)
+    {
+        ApiRequester apiRequester = requesterBuilder(ControllerConfigAPI.class)
+                .pathMethod("deleteConfigProperty")
+                .httpMethod(DELETE)
+                .resolveTemplate("file", file)
+                .resolveTemplate("property", property)
+                .accept(MediaType.TEXT_PLAIN)
+                .build();
+
+        return forwardRequest(scope, apiRequester, nodeId);
+    }
 }

--- a/presto-manager-controller/src/main/java/com/teradata/prestomanager/controller/api/ControllerConnectorAPI.java
+++ b/presto-manager-controller/src/main/java/com/teradata/prestomanager/controller/api/ControllerConnectorAPI.java
@@ -191,4 +191,27 @@ public class ControllerConnectorAPI
 
         return forwardRequest(scope, apiRequester, nodeId);
     }
+
+    @DELETE
+    @Path("/{file}/{property}")
+    @ApiOperation(value = "Delete a certain property of connector file")
+    @ApiResponses(value = {
+            @ApiResponse(code = 207, message = "Multiple responses available"),
+            @ApiResponse(code = 400, message = "Request contains invalid parameters")})
+    public Response deleteConnectorProperty(
+            @PathParam("file") String file,
+            @PathParam("property") String property,
+            @QueryParam("scope") String scope,
+            @QueryParam("nodeId") List<UUID> nodeId)
+    {
+        ApiRequester apiRequester = requesterBuilder(ControllerConnectorAPI.class)
+                .pathMethod("deleteConnectorProperty")
+                .httpMethod(DELETE)
+                .resolveTemplate("file", file)
+                .resolveTemplate("property", property)
+                .accept(MediaType.TEXT_PLAIN)
+                .build();
+
+        return forwardRequest(scope, apiRequester, nodeId);
+    }
 }


### PR DESCRIPTION
Support deletion of a certain property of configuration/connector files. This would help the user to recover if they accidentally insert an irrelevant property which would cause failure to start Presto.